### PR TITLE
Fehlerhafte Berechnung von l_22 behoben.

### DIFF
--- a/documents/Numerik/Klausur1/Aufgabe1.tex
+++ b/documents/Numerik/Klausur1/Aufgabe1.tex
@@ -124,7 +124,7 @@ Falls $A$ symmetrisch ist, gilt:
 	l_{11} &= \sqrt{a_{11}} = 3\\
 	l_{21} &= \frac{a_{21}}{l_{11}} = \frac{4}{3}\\
 	l_{31} &= \frac{a_{31}}{l_{11}} = \frac{12}{3} = 4\\
-	l_{22} &= \sqrt{a_{21} - {l_{21}}^2} = \sqrt{\frac{4}{3} - \frac{16}{9}}= \sqrt{-\frac{4}{9}} \notin \mathbb{R}\\
+	l_{22} &= \sqrt{a_{22} - {l_{21}}^2} = \sqrt{1 - \frac{16}{9}}= \sqrt{-\frac{7}{9}} \notin \mathbb{R}\\
  & \Rightarrow \text{Es ex. keine Cholesky-Zerlegung, aber $A$ ist symmetrisch}\\
  & \Rightarrow \text{$A$ ist nicht pos. Definit}
 \end{align}


### PR DESCRIPTION
Fehler bei der berechnung l_22 behoben.
Es gilt:
a_22 = l_21^2 + l_22^2

Das ändert das Resultat aber nur unwesentlich. (Bleibt negativ)
