### PR TITLE
3d-function-8.tex: convert argument of sin() to degrees.

### DIFF
--- a/tikz/3d-function-8/3d-function-8.tex
+++ b/tikz/3d-function-8/3d-function-8.tex
@@ -18,8 +18,8 @@
     view={65}{65},
     enlargelimits=false,
     grid=major,
-    domain=-5:5,
-    y domain=-5:5,
+    domain=-1:1,
+    y domain=-1:1,
     samples=50, %57 : TeX capacity exceeded, sorry [main memory size=3000000].
                 % see also http://tex.stackexchange.com/a/7954/5645
     xlabel=$x$,
@@ -33,7 +33,7 @@
         title={$f(x,y)$}
     }
     ]
-      \addplot3[surf] {(x^2+y^2)*sin(1/(x^2+y^2))};
+      \addplot3[surf] {(x^2+y^2)*sin(deg (1/(x^2+y^2)))};
     \end{axis}
 \end{tikzpicture}
 \end{preview}


### PR DESCRIPTION
tikz apparently expectes the argument to sin() in degrees. This is in
strong contrast to the usual conventions in math, where the argument is
expected in radians.

With this example it actually provides a bogus graph - it actually
should approach f(x,y) = 1 for large x and y (since 1/(x^2+y^2) is
small for large x,y; hence sin(1/(x^2+y^2)) can be approximated by
1/(x^2+y^2), resulting in f(x,y) -> 1 for large x,y).

Also I've adjusted the plot range a bit, since this then actually shows
the "interesting" center of the function (x=y=0).

Note that this image is used in Wikipedia ( https://de.wikipedia.org/wiki/Datei:3d-function-8.svg ) and should be updated there as well.